### PR TITLE
Fixed an Issue that caused build to fail on my machine

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,17 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "run",
+            "taskName": "build",
             "type": "shell",
             "command": 
-                "erl -make; erl -run main -s erlang halt"
+                "erl -make"
             
+        },
+        {
+            "taskName":"run",
+            "type": "shell",
+            "command" : "erl -run main -s erlang halt",
+            "dependsOn" : "build"
         }
     ]
 }


### PR DESCRIPTION
With the original tasks.json file build failed on my machine with the error message:
```
{"init terminating in do_boot",{undef,[{main,start,[],[]},{init,start_em,1,[{file,"init.erl"},{line,1085}]},{init,do_boot,3,[{file,"init.erl"},{line,793}]}]}}
init terminating in do_boot ({undef,[{main,start,[],[]},{init,start_em,1,[{_},{_}]},{init,do_boot,3,[{_},{_}]}]})
```
The changes submitted fixed this error